### PR TITLE
Make edit vim-compatible

### DIFF
--- a/notes.py
+++ b/notes.py
@@ -6,9 +6,7 @@ import sys
 import subprocess
 import tempfile
 
-
 from datetime import datetime
-
 
 FILENAME = os.path.expanduser("~/.daily_log")
 
@@ -53,6 +51,7 @@ def search(qs, ign):
 
     print("{}{}{}".format(before, contents[start:end], after))
 
+
 def edit_subprocess(editor):
     f, name = tempfile.mkstemp()
     # Can't use the file descriptor provided by tempfile.mkstemp in subprocess
@@ -64,9 +63,11 @@ def edit_subprocess(editor):
     log(contents)
     os.remove(name)
 
+
 def edit():
     editor = os.environ.get("EDITOR", "vi")
     edit_subprocess(editor)
+
 
 def usage():
     sys.stderr.write("usage: note [edit|search|show|args]\n")

--- a/notes.py
+++ b/notes.py
@@ -53,32 +53,20 @@ def search(qs, ign):
 
     print("{}{}{}".format(before, contents[start:end], after))
 
-def edit_vim():
+def edit_subprocess(editor):
     f, name = tempfile.mkstemp()
     # Can't use the file descriptor provided by tempfile.mkstemp in subprocess
     # Thus, we close it and create a NEW file descriptor for use in subprocess.
     os.close(f)
-    rv = subprocess.check_call(['vim', name])
-
+    rv = subprocess.check_call([editor, name])
     with open(name, 'r') as f:
         contents = f.read()
-
     log(contents)
     os.remove(name)
 
 def edit():
     editor = os.environ.get("EDITOR", "vi")
-    if 'vim' in editor:
-        edit_vim()
-    else:
-        f, name = tempfile.mkstemp()
-        os.system("{} {}".format(editor, name))
-
-        with os.fdopen(f) as f:
-            contents = f.read()
-            log(contents)
-
-        os.remove(name)
+    edit_subprocess(editor)
 
 def usage():
     sys.stderr.write("usage: note [edit|search|show|args]\n")


### PR DESCRIPTION
In order for the original process to be able to read the contents of the temporary file edited in vim, we must:

a) Close the original file descriptor before opening the editor
b) Open the file by *name* instead of file descriptor so as to access its contents

See http://vimdoc.sourceforge.net/htmldoc/options.html#'backupcopy' and the discussion of problems with crontab for a parallel problem.

The behavior is also cleaner when using subprocess.call() to launch the editor instead of os.system(). 